### PR TITLE
Add ghd command alias for easier CLI usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "table": "^6.8.1"
       },
       "bin": {
-        "gh-discussions": "dist/cli/index.js"
+        "gh-discussions": "dist/cli/index.js",
+        "ghd": "dist/cli/index.js"
       },
       "devDependencies": {
         "@types/cli-progress": "^3.11.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "dist/cli/index.js",
   "bin": {
-    "gh-discussions": "dist/cli/index.js"
+    "gh-discussions": "dist/cli/index.js",
+    "ghd": "dist/cli/index.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary
- Add 'ghd' as a shorter alias for 'gh-discussions' command
- Both commands now point to the same CLI entry point
- Improves user experience with shorter command name

## Test plan
- [x] Added ghd command to package.json bin section
- [x] Verified build process works correctly
- [x] Tested command functionality

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new "ghd" command alias so users can run the CLI with a shorter name. Both "gh-discussions" and "ghd" now start the same entry point for easier access.

<!-- End of auto-generated description by cubic. -->

